### PR TITLE
ci: GitHub Actions をコミットハッシュにピン留め (サプライチェーン攻撃対策)

### DIFF
--- a/.github/workflows/css_upgrade_pr.yml
+++ b/.github/workflows/css_upgrade_pr.yml
@@ -12,10 +12,10 @@ jobs:
       GH_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@319994f95fa847cf3fb3cd3dbe89f6dcde9f178f # v1.295.0
         with:
           ruby-version: 3.3.8
           bundler-cache: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,9 +14,9 @@ jobs:
       RAILS_ENV: test
     steps:
       - name: Checkout with push
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Setup ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@319994f95fa847cf3fb3cd3dbe89f6dcde9f178f # v1.295.0
         with:
           ruby-version: 3.4.2
           bundler-cache: true

--- a/.github/workflows/publish_gem.yml
+++ b/.github/workflows/publish_gem.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@319994f95fa847cf3fb3cd3dbe89f6dcde9f178f # v1.295.0
         with:
           ruby-version: 3.3.8
 

--- a/.github/workflows/release_pr.yml
+++ b/.github/workflows/release_pr.yml
@@ -12,12 +12,12 @@ jobs:
       GH_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0 # タグを取得するために必要
 
       - name: Setup ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@319994f95fa847cf3fb3cd3dbe89f6dcde9f178f # v1.295.0
         with:
           ruby-version: 3.3.8
           # bundler-cache を使わない (frozen mode で Gemfile.lock を更新できなくなるため)


### PR DESCRIPTION
## 概要

サプライチェーン攻撃のリスクを軽減するため、GitHub Actions のバージョン指定をタグからコミットハッシュにピン留めしました。

[pinact](https://github.com/suzuki-shunsuke/pinact) を使用して自動生成しています。

## 変更内容

| Action | 変更前 | 変更後 |
|--------|--------|--------|
| `actions/checkout` | `@v4` | `@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1` |
| `ruby/setup-ruby` | `@v1` | `@319994f95fa847cf3fb3cd3dbe89f6dcde9f178f # v1.295.0` |

## 対象ワークフロー

- `css_upgrade_pr.yml`
- `main.yml`
- `publish_gem.yml`
- `release_pr.yml`

## なぜコミットハッシュ指定が重要か

タグ (`@v4` など) は後から書き換え可能であり、悪意ある攻撃者がタグを書き換えることでサプライチェーン攻撃が成立します。コミットハッシュはイミュータブルなため、ピン留めにより特定のコードのみが実行されることが保証されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)